### PR TITLE
Adds Export line for specific SQL version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,6 +82,7 @@ ifndef UNATTENDED_CREATION
 	@echo ""
 	# setup your mysql database and link it to your app
 	@echo ""
+	@echo "export MYSQL_IMAGE_VERSION=\"5.6\""
 	@echo "dokku mysql:create $(APP_NAME)-database"
 	@echo "dokku mysql:link $(APP_NAME)-database $(APP_NAME)"
 	@echo ""


### PR DESCRIPTION
MySQL 5.7+'s mode is not compatible with the garbage nature of Wordpress's database queries.
This will save many headaches :)