### PR TITLE
Add plugin descriptor file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *
 !Makefile
+!plugin.toml
 !README.markdown
 !LICENSE.txt
 !.editorconfig

--- a/plugin.toml
+++ b/plugin.toml
@@ -1,0 +1,4 @@
+[plugin]
+description = "dokku mysql service plugin"
+version = "1.0.0"
+[plugin.config]


### PR DESCRIPTION
Prevents this type of message:
```
2017/07/17 16:10:14 open /var/lib/dokku/plugins/available/wordpress/plugin.toml: no such file or directory
```