### PR TITLE
Use shallow clone for the WordPress repository

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ ifndef WGET_INSTALLED
 endif
 endif
 	# creating the wordpress repo
-	@test -d $(APP_NAME) || (git clone --quiet https://github.com/WordPress/WordPress.git $(APP_NAME) && cd $(APP_NAME) && git checkout -q tags/$(WORDPRESS_VERSION) && git branch -qD master && git checkout -qb master)
+	@test -d $(APP_NAME) || (git clone --quiet --depth=1 https://github.com/WordPress/WordPress.git $(APP_NAME) -b $(WORDPRESS_VERSION) && cd $(APP_NAME) && git checkout -qb master)
 	# adding wp-config.php from gist
 	@test -f $(APP_NAME)/wp-config.php || (cp config/wp-config.php $(APP_NAME)/wp-config.php && cd $(APP_NAME) && git add wp-config.php && git commit -qm "Adding environment-variable based wp-config.php")
 	# adding .env file to configure buildpack


### PR DESCRIPTION
No need to clone the whole wordpress repo. Here are some benchmarks regarding the time `make` took and how big the wordpress repo is after cloning.

## Before

```
time make build SERVER_NAME=dokku.me APP_NAME=wp1
44,72s user 3,05s system 97% cpu 48,811 total

du -sh *
215M wp1
```

## After

```
time make build SERVER_NAME=dokku.me APP_NAME=wp2
2,97s user 0,26s system 33% cpu 9,649 total

du -sh *
44M wp2
```
