### PR TITLE
Avoid redirect loop if WordPress is behind a TLS proxy

### DIFF
--- a/config/wp-config.php
+++ b/config/wp-config.php
@@ -89,6 +89,14 @@ $table_prefix  = fromenv('TABLE_PREFIX', 'wp_');
  */
 define('WP_DEBUG', (bool)fromenv('WP_DEBUG', false));
 
+// If we're behind a proxy server and using HTTPS, we need to alert Wordpress of that fact
+// see also http://codex.wordpress.org/Administration_Over_SSL#Using_a_Reverse_Proxy
+if ( isset($_SERVER['HTTP_X_FORWARDED_PROTO'] )
+    && $_SERVER['HTTP_X_FORWARDED_PROTO'] === 'https' )
+{
+    $_SERVER['HTTPS'] = 'on';
+}
+
 /* That's all, stop editing! Happy blogging. */
 
 /** Absolute path to the WordPress directory. */


### PR DESCRIPTION
If WordPress is hosted behind a reverse proxy that provides SSL, but is
hosted itself without SSL, these options will initially send any
requests into an infinite redirect loop. To avoid this, we must
configure WordPress to recognize the HTTP_X_FORWARDED_PROTO header.

https://codex.wordpress.org/Administration_Over_SSL#Using_a_Reverse_Proxy

PS. This is also set by the official WordPress Docker image https://github.com/docker-library/wordpress/blob/7902c5f856c7fbc20dd70762bef324158328dcff/php7.1/fpm/docker-entrypoint.sh#L109-L115