### PR TITLE
Add PHP 7 to supported versions

### DIFF
--- a/config/composer.json
+++ b/config/composer.json
@@ -1,1 +1,1 @@
-{"require": {"php": ">=5.6", "ext-mysql": "*", "ext-gd": "*"}}
+{"require": {"php": ">=5.6", "ext-gd": "*"}}

--- a/config/composer.lock
+++ b/config/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "ac554f725402046fcbaead92cb2c4451",
+    "content-hash": "2c47ba96599cc3aa60317886030d0ce5",
     "packages": [],
     "packages-dev": [],
     "aliases": [],
@@ -14,7 +14,6 @@
     "prefer-lowest": false,
     "platform": {
         "php": ">=5.6",
-        "ext-mysql": "*",
         "ext-gd": "*"
     },
     "platform-dev": []


### PR DESCRIPTION
Reasons to update PHP:

- PHP 7 is much faster and more efficient than PHP 5.6.
- WordPress lists PHP 7.2 in its requirements https://wordpress.org/about/requirements/
- Heroku PHP buildpack already supports 7.2 https://devcenter.heroku.com/articles/php-support#php-runtimes.

The `mysql` extension is enabled by default in PHP 5.6 and up, so no need to require it https://devcenter.heroku.com/articles/php-support#extensions.

Closes #15 