### PR TITLE
modify makefile to make languages dir persistent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,6 +80,12 @@ ifndef UNATTENDED_CREATION
 	@echo "chown 32767:32767 /var/lib/dokku/data/storage/$(APP_NAME)-uploads"
 	@echo "dokku storage:mount $(APP_NAME) /var/lib/dokku/data/storage/$(APP_NAME)-uploads:/app/wp-content/uploads"
 	@echo ""
+	# setup languages persistent storage
+	@echo ""
+	@echo "mkdir -p /var/lib/dokku/data/storage/$(APP_NAME)-languages"
+	@echo "chown 32767:32767 /var/lib/dokku/data/storage/$(APP_NAME)-languages"
+	@echo "dokku storage:mount $(APP_NAME) /var/lib/dokku/data/storage/$(APP_NAME)-languages:/app/wp-content/languages"
+	@echo ""
 	# setup your mysql database and link it to your app
 	# if you're using MariaDB, replace mysql with mariadb
 	@echo ""
@@ -102,6 +108,7 @@ else
 	$(DOKKU_CMD) apps:create $(APP_NAME)
 	$(DOKKU_CMD) storage:mount $(APP_NAME) /var/lib/dokku/data/storage/$(APP_NAME)-plugins:/app/wp-content/plugins
 	$(DOKKU_CMD) storage:mount $(APP_NAME) /var/lib/dokku/data/storage/$(APP_NAME)-uploads:/app/wp-content/uploads
+	$(DOKKU_CMD) storage:mount $(APP_NAME) /var/lib/dokku/data/storage/$(APP_NAME)-languages:/app/wp-content/languages
 	$(DOKKU_CMD) mysql:create $(APP_NAME)-database
 	$(DOKKU_CMD) mysql:link $(APP_NAME)-database $(APP_NAME)
 	@/tmp/wp-salts
@@ -112,6 +119,8 @@ else
 	@echo "chown 32767:32767 /var/lib/dokku/data/storage/$(APP_NAME)-plugins"
 	@echo "mkdir -p /var/lib/dokku/data/storage/$(APP_NAME)-uploads"
 	@echo "chown 32767:32767 /var/lib/dokku/data/storage/$(APP_NAME)-uploads"
+	@echo "mkdir -p /var/lib/dokku/data/storage/$(APP_NAME)-languages"
+	@echo "chown 32767:32767 /var/lib/dokku/data/storage/$(APP_NAME)-languages"
 	@echo ""
 	# now, on your local machine, change directory to your new wordpress app, and push it up
 	@echo ""
@@ -142,6 +151,7 @@ ifndef UNATTENDED_CREATION
 	@echo ""
 	@echo "rm -rf /var/lib/dokku/data/storage/$(APP_NAME)-plugins"
 	@echo "rm -rf /var/lib/dokku/data/storage/$(APP_NAME)-uploads"
+	@echo "rm -rf /var/lib/dokku/data/storage/$(APP_NAME)-languages"
 	@echo ""
 	# now, on your local machine, cd into your app's parent directory and remove the app
 	@echo ""
@@ -157,6 +167,7 @@ else
 	@echo ""
 	@echo "rm -rf /var/lib/dokku/data/storage/$(APP_NAME)-plugins"
 	@echo "rm -rf /var/lib/dokku/data/storage/$(APP_NAME)-uploads"
+	@echo "rm -rf /var/lib/dokku/data/storage/$(APP_NAME)-languages"
 	@echo ""
 	# now, on your local machine, cd into your app's parent directory and remove the app
 	@echo ""


### PR DESCRIPTION
Later versions of Wordpress store translations in `wp-content/languages`.  I believe this directory should be made persistent (like plugins and uploads are) so that translation upgrades via the wordpress admin UI can easily be made.

Copying translations into a local repo and pushing them up is not a good alternative since the files and directory structures of that directory are nested and complex 

.. |   |   |  
-- | -- | -- | --
plugins |   |   |  
themes |   |   |  
admin-en_AU.mo | 374.03 Kb | 2018-Oct-29 |  
admin-en_AU.po | 518.38 Kb | 2018-Oct-29 |  
admin-network-en_AU.mo | 41.71 Kb | 2018-Oct-29 |  
admin-network-en_AU.po | 56.81 Kb | 2018-Oct-29 |  
en_AU.mo | 238.07 Kb | 2018-Oct-29 |  
en_AU.po | 414.71 Kb | 2018-Oct-29 |

and change when new plugins are added and translations upgraded.  There is no easy way to determine what files to put into the local repo except to apply upgrades on the server, note the differences and copy them down to the local repo - which is laborious and error prone.

A simple change to the makefile to make this directory be persistent is a much cleaner and user friendly solution.  I've tried this change and it works. Note that the need for language upgrades only kicks in when you switch wordpress to a non US language.

