### PR TITLE
Show clone progress but suppress "detached head" warning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ ifndef WGET_INSTALLED
 endif
 endif
 	# creating the wordpress repo
-	@test -d $(APP_NAME) || (git clone --quiet --branch=$(WORDPRESS_VERSION) --single-branch https://github.com/WordPress/WordPress.git $(APP_NAME) && cd $(APP_NAME) && git checkout -qb master)
+	@test -d $(APP_NAME) || (git -c advice.detachedHead=false clone --branch=$(WORDPRESS_VERSION) --single-branch https://github.com/WordPress/WordPress.git $(APP_NAME) && cd $(APP_NAME) && git checkout -qb master)
 	# adding wp-config.php from gist
 	@test -f $(APP_NAME)/wp-config.php || (cp config/wp-config.php $(APP_NAME)/wp-config.php && cd $(APP_NAME) && git add wp-config.php && git commit -qm "Adding environment-variable based wp-config.php")
 	# adding .env file to configure buildpack


### PR DESCRIPTION
It's nice to see progress on a long-running command (git clone) but the "detached head" warning isn't pertinent and moreover is potentially confusing